### PR TITLE
Persist autonomous runner artifacts and track attempts

### DIFF
--- a/contracts/FlashFloopExecutor.sol
+++ b/contracts/FlashFloopExecutor.sol
@@ -29,6 +29,8 @@ contract FlashFloopExecutor {
     error NotOwner();
     error BadLengths();
     error InsufficientProfit(uint256 have, uint256 need);
+    error UnexpectedLoanToken(address expected, address actual);
+    error UnexpectedLoanAmount(uint256 expected, uint256 actual);
     error ExternalCallFailed(uint256 index, bytes reason);
 
     address public immutable vault;
@@ -83,6 +85,13 @@ contract FlashFloopExecutor {
         require(msg.sender == vault, "only vault");
         (address[] memory targets, bytes[] memory datas, address loanToken, uint256 loanAmount, uint256 minProfit, address to)
             = abi.decode(userData, (address[], bytes[], address, uint256, uint256, address));
+
+        if (tokens.length != 1 || tokens[0] != loanToken) {
+            revert UnexpectedLoanToken(loanToken, tokens.length == 0 ? address(0) : tokens[0]);
+        }
+        if (amounts.length != 1 || amounts[0] != loanAmount) {
+            revert UnexpectedLoanAmount(loanAmount, amounts.length == 0 ? 0 : amounts[0]);
+        }
 
         // Run pipeline
         for (uint256 i = 0; i < targets.length; i++) {

--- a/contracts/mocks/MockBalancerVault.sol
+++ b/contracts/mocks/MockBalancerVault.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+interface IFlashLoanRecipient {
+    function receiveFlashLoan(
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        uint256[] calldata feeAmounts,
+        bytes calldata userData
+    ) external;
+}
+
+contract MockBalancerVault {
+    error NotRepaid();
+
+    uint256 public flashFee;
+    address[] private overrideTokens;
+    uint256[] private overrideAmounts;
+
+    function setFlashFee(uint256 newFee) external {
+        flashFee = newFee;
+    }
+
+    function setOverrideResponse(address[] calldata tokens, uint256[] calldata amounts) external {
+        require(tokens.length == amounts.length, "MockBalancerVault: bad override lengths");
+        overrideTokens = tokens;
+        overrideAmounts = amounts;
+    }
+
+    function flashLoan(
+        address recipient,
+        address[] memory tokens,
+        uint256[] memory amounts,
+        bytes memory userData
+    ) external {
+        require(tokens.length == 1 && amounts.length == 1, "MockBalancerVault: only single token supported");
+
+        address[] memory callbackTokens = overrideTokens.length == 0 ? tokens : overrideTokens;
+        uint256[] memory callbackAmounts = overrideAmounts.length == 0 ? amounts : overrideAmounts;
+
+        delete overrideTokens;
+        delete overrideAmounts;
+
+        IERC20 loanToken = IERC20(callbackTokens[0]);
+        uint256 loanAmount = callbackAmounts[0];
+        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        loanToken.transfer(recipient, loanAmount);
+
+        uint256[] memory feeAmounts = new uint256[](callbackTokens.length);
+        for (uint256 i = 0; i < callbackTokens.length; i++) {
+            feeAmounts[i] = flashFee;
+        }
+
+        IFlashLoanRecipient(recipient).receiveFlashLoan(callbackTokens, callbackAmounts, feeAmounts, userData);
+
+        uint256 expectedBalance = balanceBefore + flashFee;
+        if (loanToken.balanceOf(address(this)) < expectedBalance) {
+            revert NotRepaid();
+        }
+    }
+}

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= amount, "MockERC20: insufficient allowance");
+            allowance[from][msg.sender] = allowed - amount;
+            emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "MockERC20: insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/contracts/mocks/MockPipelineTarget.sol
+++ b/contracts/mocks/MockPipelineTarget.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+contract MockPipelineTarget {
+    function send(address token, address to, uint256 amount) external {
+        require(IERC20(token).transfer(to, amount), "MockPipelineTarget: transfer failed");
+    }
+
+    function fail() external pure {
+        revert("MockPipelineTarget: failure");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-verify": "^2.0.6",
+    "@types/chai": "4.3.11",
+    "chai": "4.3.10",
     "hardhat": "^2.22.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,12 +33,21 @@ importers:
         specifier: ^8.18.3
         version: 8.18.3
     devDependencies:
+      '@nomicfoundation/hardhat-chai-matchers':
+        specifier: ^2.1.0
+        version: 2.1.0(@nomicfoundation/hardhat-ethers@3.1.0(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2)))(chai@4.3.10)(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
         version: 3.1.0(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))
       '@nomicfoundation/hardhat-verify':
         specifier: ^2.0.6
         version: 2.1.1(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))
+      '@types/chai':
+        specifier: 4.3.11
+        version: 4.3.11
+      chai:
+        specifier: 4.3.10
+        version: 4.3.10
       hardhat:
         specifier: ^2.22.10
         version: 2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2)
@@ -210,6 +219,14 @@ packages:
     resolution: {integrity: sha512-kqILRkAd455Sd6v8mfP3C1/0tCOynJWY+Ir+k/9Boocu2kObCrsFgG+ZWB7fSBVdd9cPVSNrnhWS+V+PEo637g==}
     engines: {node: '>= 18'}
 
+  '@nomicfoundation/hardhat-chai-matchers@2.1.0':
+    resolution: {integrity: sha512-GPhBNafh1fCnVD9Y7BYvoLnblnvfcq3j8YDbO1gGe/1nOFWzGmV7gFu5DkwFXF+IpYsS+t96o9qc/mPu3V3Vfw==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-ethers': ^3.1.0
+      chai: ^4.2.0
+      ethers: ^6.14.0
+      hardhat: ^2.26.0
+
   '@nomicfoundation/hardhat-ethers@3.1.0':
     resolution: {integrity: sha512-jx6fw3Ms7QBwFGT2MU6ICG292z0P81u6g54JjSV105+FbTZOF4FJqPksLfDybxkkOeq28eDxbqq7vpxRYyIlxA==}
     peerDependencies:
@@ -317,6 +334,12 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/chai-as-promised@7.1.8':
+    resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
+
+  '@types/chai@4.3.11':
+    resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
+
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
@@ -390,6 +413,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -439,9 +465,21 @@ packages:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
     engines: {node: '>=12.19'}
 
+  chai-as-promised@7.1.2:
+    resolution: {integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==}
+    peerDependencies:
+      chai: '>= 2.1.2 < 6'
+
+  chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -502,6 +540,10 @@ packages:
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -608,6 +650,9 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -751,6 +796,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   lru_map@0.3.3:
     resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
 
@@ -818,6 +866,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  ordinal@1.0.3:
+    resolution: {integrity: sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -848,6 +899,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1002,6 +1056,10 @@ packages:
 
   tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -1357,6 +1415,17 @@ snapshots:
       '@nomicfoundation/edr-linux-x64-musl': 0.11.3
       '@nomicfoundation/edr-win32-x64-msvc': 0.11.3
 
+  '@nomicfoundation/hardhat-chai-matchers@2.1.0(@nomicfoundation/hardhat-ethers@3.1.0(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2)))(chai@4.3.10)(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.1.0(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.3.10
+      chai-as-promised: 7.1.2(chai@4.3.10)
+      deep-eql: 4.1.4
+      ethers: 6.15.0
+      hardhat: 2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2)
+      ordinal: 1.0.3
+
   '@nomicfoundation/hardhat-ethers@3.1.0(ethers@6.15.0)(hardhat@2.26.3(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))(typescript@5.9.2))':
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
@@ -1506,6 +1575,12 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/chai-as-promised@7.1.8':
+    dependencies:
+      '@types/chai': 4.3.11
+
+  '@types/chai@4.3.11': {}
+
   '@types/node@20.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -1571,6 +1646,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@1.1.0: {}
+
   astral-regex@2.0.0: {}
 
   balanced-match@1.0.2: {}
@@ -1614,10 +1691,29 @@ snapshots:
     dependencies:
       nofilter: 3.1.0
 
+  chai-as-promised@7.1.2(chai@4.3.10):
+    dependencies:
+      chai: 4.3.10
+      check-error: 1.0.3
+
+  chai@4.3.10:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.6.0:
     dependencies:
@@ -1670,6 +1766,10 @@ snapshots:
       supports-color: 8.1.1
 
   decamelize@4.0.0: {}
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
 
   depd@2.0.0: {}
 
@@ -1768,6 +1868,8 @@ snapshots:
     optional: true
 
   get-caller-file@2.0.5: {}
+
+  get-func-name@2.0.2: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -1940,6 +2042,10 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru_map@0.3.3: {}
 
   make-error@1.3.6: {}
@@ -2011,6 +2117,8 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  ordinal@1.0.3: {}
+
   os-tmpdir@1.0.2: {}
 
   ox@0.8.6(typescript@5.9.2):
@@ -2043,6 +2151,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2198,6 +2308,8 @@ snapshots:
   tslib@2.7.0: {}
 
   tsort@0.0.1: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 

--- a/scripts/autonomous-runner.ts
+++ b/scripts/autonomous-runner.ts
@@ -1,0 +1,361 @@
+import { ethers, network } from 'hardhat';
+import { Contract, Signer } from 'ethers';
+import { setTimeout as delay } from 'timers/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+
+const ERC20_ABI = [
+  'function decimals() view returns (uint8)',
+  'function balanceOf(address) view returns (uint256)'
+];
+
+export interface CallInstruction {
+  target: string;
+  calldata: string;
+  description?: string;
+}
+
+export interface TargetInstruction {
+  address: string;
+  calldata: string;
+  description?: string;
+}
+
+export interface LoanConfig {
+  token: string;
+  amount: string;
+  minProfit: string;
+  decimals?: number;
+}
+
+export interface AutonomousPlanDefinition {
+  vault: string;
+  executor?: string;
+  owner?: string;
+  loan: LoanConfig;
+  profitRecipient?: string;
+  targets: TargetInstruction[];
+  startupActions?: CallInstruction[];
+  preRunActions?: CallInstruction[];
+  retryActions?: CallInstruction[];
+  maxRuns?: number;
+  stopOnSuccess?: boolean;
+  continueOnFailure?: boolean;
+  cooldownMs?: number;
+  maxDurationSeconds?: number;
+  artifactBasePath?: string;
+  runLabel?: string;
+}
+
+export interface RunSummary {
+  success: boolean;
+  runs: number;
+  profit: bigint;
+  finalRecipientBalance: bigint;
+  lastError?: string;
+  executor: string;
+  terminatedReason: 'success' | 'max_runs_reached' | 'duration_exceeded' | 'aborted_on_failure';
+  artifactPath: string;
+  attempts: RunAttemptRecord[];
+  startedAt: string;
+  finishedAt: string;
+}
+
+export interface RunAttemptRecord {
+  index: number;
+  startedAt: string;
+  durationMs?: number;
+  txHash?: string;
+  blockNumber?: number;
+  gasUsed?: string;
+  gasPriceWei?: string;
+  profitDelta?: string;
+  recipientBalance?: string;
+  success: boolean;
+  error?: string;
+  retryActionsRun?: boolean;
+}
+
+const JSON_REPLACER = (_: string, value: unknown) =>
+  typeof value === 'bigint' ? value.toString() : value;
+
+async function safeWriteJson(filePath: string, payload: unknown) {
+  try {
+    await writeFile(filePath, JSON.stringify(payload, JSON_REPLACER, 2));
+  } catch (error) {
+    console.warn(`Failed to write ${filePath}:`, formatError(error));
+  }
+}
+
+function sanitizePlanForLog(plan: AutonomousPlanDefinition): Record<string, unknown> {
+  const { artifactBasePath, runLabel, ...rest } = plan;
+  return rest as Record<string, unknown>;
+}
+
+function renderReport(summary: RunSummary, plan: AutonomousPlanDefinition): string {
+  const lines: string[] = [];
+  lines.push('# Autonomous Runner Report');
+  lines.push('');
+  lines.push(`- Started: ${summary.startedAt}`);
+  lines.push(`- Finished: ${summary.finishedAt}`);
+  lines.push(`- Runs executed: ${summary.runs}`);
+  lines.push(`- Terminated reason: ${summary.terminatedReason}`);
+  lines.push(`- Success: ${summary.success}`);
+  lines.push(`- Profit (raw): ${summary.profit.toString()}`);
+  lines.push(`- Final recipient balance: ${summary.finalRecipientBalance.toString()}`);
+  if (summary.lastError) {
+    lines.push(`- Last error: ${summary.lastError}`);
+  }
+  lines.push('');
+  lines.push('## Plan Snapshot');
+  lines.push('');
+  lines.push('```json');
+  lines.push(JSON.stringify(sanitizePlanForLog(plan), JSON_REPLACER, 2));
+  lines.push('```');
+  lines.push('');
+  lines.push('## Attempts');
+  lines.push('');
+  lines.push('| # | Started | Success | TxHash | Profit Δ | Error | Duration (ms) | Retry Actions |');
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+  for (const attempt of summary.attempts) {
+    lines.push(
+      `| ${attempt.index} | ${attempt.startedAt} | ${attempt.success} | ${attempt.txHash ?? ''} | ${attempt.profitDelta ?? ''} | ${attempt.error ?? ''} | ${attempt.durationMs ?? ''} | ${attempt.retryActionsRun ? 'yes' : 'no'} |`
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function parseTokenAmount(value: string, decimals: number): bigint {
+  if (value.startsWith('0x')) {
+    return BigInt(value);
+  }
+  return ethers.parseUnits(value, decimals);
+}
+
+async function resolveSigner(address?: string): Promise<Signer> {
+  const available = await ethers.getSigners();
+  if (!address) {
+    return available[0];
+  }
+  const needle = address.toLowerCase();
+  for (const signer of available) {
+    if ((await signer.getAddress()).toLowerCase() === needle) {
+      return signer;
+    }
+  }
+  await network.provider.request({ method: 'hardhat_impersonateAccount', params: [address] });
+  return await ethers.getSigner(address);
+}
+
+async function performCalls(actions: CallInstruction[] | undefined, signer: Signer) {
+  if (!actions?.length) return;
+  for (const action of actions) {
+    const tx = await signer.sendTransaction({ to: action.target, data: action.calldata });
+    await tx.wait();
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+export async function runAutonomousPlan(plan: AutonomousPlanDefinition): Promise<RunSummary> {
+  if (plan.targets.length === 0) {
+    throw new Error('Plan must specify at least one target');
+  }
+
+  const ownerSigner = await resolveSigner(plan.owner);
+  const ownerAddress = await ownerSigner.getAddress();
+
+  const decimals = plan.loan.decimals ?? Number(await new ethers.Contract(plan.loan.token, ERC20_ABI, ownerSigner).decimals());
+  const loanAmount = parseTokenAmount(plan.loan.amount, decimals);
+  const minProfit = parseTokenAmount(plan.loan.minProfit, decimals);
+
+  const profitRecipient = plan.profitRecipient ?? ownerAddress;
+
+  const startedAt = new Date();
+  const startedAtIso = startedAt.toISOString();
+  const artifactBase = path.resolve(plan.artifactBasePath ?? path.join(process.cwd(), 'runs'));
+  const runLabel = plan.runLabel ?? startedAtIso.replace(/[:.]/g, '-');
+  const artifactPath = path.join(artifactBase, runLabel);
+  await mkdir(artifactPath, { recursive: true });
+  await safeWriteJson(path.join(artifactPath, 'plan.json'), sanitizePlanForLog(plan));
+
+  const attemptsPath = path.join(artifactPath, 'attempts.json');
+  const attempts: RunAttemptRecord[] = [];
+
+  let executor: Contract;
+  if (plan.executor) {
+    executor = await ethers.getContractAt('FlashFloopExecutor', plan.executor, ownerSigner);
+  } else {
+    const executorFactory = await ethers.getContractFactory('FlashFloopExecutor', ownerSigner);
+    executor = await executorFactory.deploy(plan.vault);
+    await executor.waitForDeployment();
+  }
+
+  const executorAddress = await executor.getAddress();
+
+  const currentOwner: string = await executor.owner();
+  if (currentOwner.toLowerCase() !== ownerAddress.toLowerCase()) {
+    const tx = await executor.connect(ownerSigner).setOwner(ownerAddress);
+    await tx.wait();
+  }
+
+  const erc20 = new ethers.Contract(plan.loan.token, ERC20_ABI, ownerSigner);
+  const initialBalance: bigint = await erc20.balanceOf(profitRecipient);
+
+  await performCalls(plan.startupActions, ownerSigner);
+
+  const configuredMaxRuns = plan.maxRuns ?? 5;
+  const unlimitedRuns = configuredMaxRuns <= 0;
+  const maxRuns = unlimitedRuns ? Number.POSITIVE_INFINITY : configuredMaxRuns;
+  const stopOnSuccess = plan.stopOnSuccess !== false;
+  const continueOnFailure = plan.continueOnFailure !== false;
+  const cooldownMs = Math.max(0, plan.cooldownMs ?? 0);
+  const maxDurationSeconds = plan.maxDurationSeconds ?? 0;
+  const maxDurationMs = maxDurationSeconds > 0 ? maxDurationSeconds * 1000 : 0;
+  const startTime = Date.now();
+
+  const targetAddresses = plan.targets.map((t) => t.address);
+  const calldatas = plan.targets.map((t) => t.calldata);
+
+  let runs = 0;
+  let success = false;
+  let profit = 0n;
+  let lastError: string | undefined;
+  let terminatedReason: RunSummary['terminatedReason'] | undefined;
+
+  while (runs < maxRuns) {
+    if (maxDurationMs && Date.now() - startTime >= maxDurationMs) {
+      terminatedReason = 'duration_exceeded';
+      break;
+    }
+
+    const attemptIndex = runs + 1;
+    const attemptStart = Date.now();
+    const attemptRecord: RunAttemptRecord = {
+      index: attemptIndex,
+      startedAt: new Date().toISOString(),
+      success: false
+    };
+    attempts.push(attemptRecord);
+    await safeWriteJson(attemptsPath, attempts);
+
+    try {
+      await performCalls(plan.preRunActions, ownerSigner);
+      const tx = await executor.connect(ownerSigner).execute({
+        targets: targetAddresses,
+        calldatas,
+        loanToken: plan.loan.token,
+        loanAmount,
+        minProfit,
+        profitRecipient
+      });
+      attemptRecord.txHash = tx.hash;
+      const receipt = await tx.wait();
+      attemptRecord.blockNumber = receipt.blockNumber ?? undefined;
+      attemptRecord.gasUsed = receipt.gasUsed?.toString();
+      attemptRecord.gasPriceWei = (receipt.effectiveGasPrice ?? 0n).toString();
+
+      const currentBalance: bigint = await erc20.balanceOf(profitRecipient);
+      profit = currentBalance - initialBalance;
+      attemptRecord.recipientBalance = currentBalance.toString();
+      attemptRecord.profitDelta = profit.toString();
+      attemptRecord.success = profit >= minProfit;
+      attemptRecord.durationMs = Date.now() - attemptStart;
+
+      if (profit >= minProfit) {
+        success = true;
+        terminatedReason = 'success';
+        if (stopOnSuccess) {
+          runs += 1;
+          break;
+        }
+      }
+    } catch (error) {
+      lastError = formatError(error);
+      attemptRecord.error = lastError;
+      attemptRecord.durationMs = Date.now() - attemptStart;
+      const currentBalance: bigint = await erc20.balanceOf(profitRecipient);
+      profit = currentBalance - initialBalance;
+      attemptRecord.recipientBalance = currentBalance.toString();
+      attemptRecord.profitDelta = profit.toString();
+      await safeWriteJson(attemptsPath, attempts);
+      if (!continueOnFailure) {
+        terminatedReason = 'aborted_on_failure';
+        throw error;
+      }
+      await performCalls(plan.retryActions, ownerSigner);
+      attemptRecord.retryActionsRun = Boolean(plan.retryActions && plan.retryActions.length > 0);
+    }
+
+    runs += 1;
+    await safeWriteJson(attemptsPath, attempts);
+
+    if (cooldownMs > 0 && runs < maxRuns && (!maxDurationMs || Date.now() - startTime < maxDurationMs)) {
+      await delay(cooldownMs);
+    }
+  }
+
+  const finalBalance: bigint = await erc20.balanceOf(profitRecipient);
+
+  if (!terminatedReason) {
+    terminatedReason = success ? 'success' : 'max_runs_reached';
+  }
+
+  const finishedAtIso = new Date().toISOString();
+
+  const summary: RunSummary = {
+    success,
+    runs,
+    profit,
+    finalRecipientBalance: finalBalance,
+    lastError,
+    executor: executorAddress,
+    terminatedReason,
+    artifactPath,
+    attempts,
+    startedAt: startedAtIso,
+    finishedAt: finishedAtIso
+  };
+
+  await safeWriteJson(path.join(artifactPath, 'summary.json'), summary);
+  await safeWriteJson(path.join(artifactPath, 'attempts.json'), attempts);
+
+  const reportPath = path.join(artifactPath, 'REPORT.md');
+  try {
+    await writeFile(reportPath, renderReport(summary, plan));
+  } catch (error) {
+    console.warn(`Failed to write ${reportPath}:`, formatError(error));
+  }
+
+  return summary;
+}
+
+export async function runAutonomousPlanFromFile(planPath: string): Promise<RunSummary> {
+  const absolute = path.resolve(planPath);
+  const raw = await readFile(absolute, 'utf8');
+  const parsed = JSON.parse(raw) as AutonomousPlanDefinition;
+  return runAutonomousPlan(parsed);
+}
+
+if (require.main === module) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error('Usage: hardhat run scripts/autonomous-runner.ts --network <network> <plan.json>');
+    process.exit(1);
+  }
+
+  runAutonomousPlanFromFile(planPath)
+    .then((summary) => {
+      console.log(JSON.stringify(summary, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2));
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/test/AutonomousRunner.ts
+++ b/test/AutonomousRunner.ts
@@ -1,0 +1,181 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import '@nomicfoundation/hardhat-chai-matchers';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { runAutonomousPlan, AutonomousPlanDefinition } from '../scripts/autonomous-runner';
+
+describe('Autonomous runner integration', function () {
+  it('retries failed runs and stops once profitable', async function () {
+    const [deployer, recipient] = await ethers.getSigners();
+    const recipientAddress = await recipient.getAddress();
+
+    const tokenFactory = await ethers.getContractFactory('MockERC20');
+    const token = await tokenFactory.deploy('Mock Token', 'MOCK', 18);
+    await token.waitForDeployment();
+
+    const vaultFactory = await ethers.getContractFactory('MockBalancerVault');
+    const vault = await vaultFactory.deploy();
+    await vault.waitForDeployment();
+
+    const targetFactory = await ethers.getContractFactory('MockPipelineTarget');
+    const target = await targetFactory.deploy();
+    await target.waitForDeployment();
+
+    const executorFactory = await ethers.getContractFactory('FlashFloopExecutor');
+    const executor = await executorFactory.deploy(await vault.getAddress());
+    await executor.waitForDeployment();
+
+    const vaultAddress = await vault.getAddress();
+    const tokenAddress = await token.getAddress();
+    const targetAddress = await target.getAddress();
+    const executorAddress = await executor.getAddress();
+
+    const fee = ethers.parseUnits('0.01', 18);
+    const minProfit = ethers.parseUnits('0.05', 18);
+    const extraProfit = ethers.parseUnits('0.02', 18);
+    const profitTransfer = fee + minProfit + extraProfit;
+
+    await token.mint(vaultAddress, ethers.parseUnits('1000000', 18));
+    await vault.setFlashFee(fee);
+
+    // Intentionally underfund the pipeline target so the first execution reverts.
+    await token.mint(targetAddress, fee);
+
+    const targetCalldata = target.interface.encodeFunctionData('send', [
+      tokenAddress,
+      executorAddress,
+      profitTransfer
+    ]);
+
+    const artifactRoot = mkdtempSync(path.join(os.tmpdir(), 'autonomous-runner-'));
+
+    const plan: AutonomousPlanDefinition = {
+      vault: vaultAddress,
+      executor: executorAddress,
+      owner: await deployer.getAddress(),
+      loan: {
+        token: tokenAddress,
+        amount: '100',
+        minProfit: '0.05',
+        decimals: 18
+      },
+      profitRecipient: recipientAddress,
+      targets: [
+        {
+          address: targetAddress,
+          calldata: targetCalldata
+        }
+      ],
+      maxRuns: 3,
+      continueOnFailure: true,
+      retryActions: [
+        {
+          target: tokenAddress,
+          calldata: token.interface.encodeFunctionData('mint', [targetAddress, profitTransfer])
+        }
+      ],
+      artifactBasePath: artifactRoot,
+      runLabel: 'success-case'
+    };
+
+    try {
+      const summary = await runAutonomousPlan(plan);
+
+      expect(summary.success).to.be.true;
+      expect(summary.runs).to.equal(2);
+      expect(summary.profit).to.equal(minProfit + extraProfit);
+      expect(summary.finalRecipientBalance).to.equal(minProfit + extraProfit);
+      expect(summary.lastError).to.contain('ExternalCallFailed');
+      expect(summary.terminatedReason).to.equal('success');
+      expect(summary.attempts).to.have.length(2);
+      expect(summary.attempts[0].success).to.be.false;
+      expect(summary.attempts[0].error).to.include('ExternalCallFailed');
+      expect(summary.attempts[0].retryActionsRun).to.be.true;
+      expect(summary.attempts[1].success).to.be.true;
+      expect(summary.artifactPath).to.include('success-case');
+      expect(summary.startedAt).to.be.a('string');
+      expect(summary.finishedAt).to.be.a('string');
+
+      const summaryPath = path.join(summary.artifactPath, 'summary.json');
+      const attemptsPath = path.join(summary.artifactPath, 'attempts.json');
+      const parsedSummary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+      const parsedAttempts = JSON.parse(readFileSync(attemptsPath, 'utf8'));
+      expect(parsedSummary.terminatedReason).to.equal('success');
+      expect(parsedSummary.runs).to.equal(2);
+      expect(parsedAttempts).to.have.length(2);
+    } finally {
+      rmSync(artifactRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('allows unlimited retries with cooldown and duration guardrails', async function () {
+    const [deployer] = await ethers.getSigners();
+
+    const tokenFactory = await ethers.getContractFactory('MockERC20');
+    const token = await tokenFactory.deploy('Mock Token', 'MOCK', 18);
+    await token.waitForDeployment();
+
+    const vaultFactory = await ethers.getContractFactory('MockBalancerVault');
+    const vault = await vaultFactory.deploy();
+    await vault.waitForDeployment();
+
+    const targetFactory = await ethers.getContractFactory('MockPipelineTarget');
+    const target = await targetFactory.deploy();
+    await target.waitForDeployment();
+
+    const executorFactory = await ethers.getContractFactory('FlashFloopExecutor');
+    const executor = await executorFactory.deploy(await vault.getAddress());
+    await executor.waitForDeployment();
+
+    const vaultAddress = await vault.getAddress();
+    const tokenAddress = await token.getAddress();
+    const executorAddress = await executor.getAddress();
+    const targetAddress = await target.getAddress();
+
+    await token.mint(vaultAddress, ethers.parseUnits('1000000', 18));
+    await vault.setFlashFee(0n);
+
+    const failCalldata = target.interface.encodeFunctionData('fail');
+
+    const artifactRoot = mkdtempSync(path.join(os.tmpdir(), 'autonomous-runner-'));
+
+    const plan: AutonomousPlanDefinition = {
+      vault: vaultAddress,
+      executor: executorAddress,
+      owner: await deployer.getAddress(),
+      loan: {
+        token: tokenAddress,
+        amount: '10',
+        minProfit: '0',
+        decimals: 18
+      },
+      targets: [
+        {
+          address: targetAddress,
+          calldata: failCalldata
+        }
+      ],
+      maxRuns: 0,
+      cooldownMs: 5,
+      maxDurationSeconds: 0.001,
+      artifactBasePath: artifactRoot,
+      runLabel: 'duration-guard'
+    };
+
+    try {
+      const summary = await runAutonomousPlan(plan);
+
+      expect(summary.success).to.be.false;
+      expect(summary.runs).to.be.at.most(1);
+      expect(summary.terminatedReason).to.equal('duration_exceeded');
+      expect(summary.lastError).to.include('ExternalCallFailed');
+      expect(summary.attempts.length).to.be.at.least(1);
+      expect(summary.artifactPath).to.include('duration-guard');
+    } finally {
+      rmSync(artifactRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/FlashFloopExecutor.ts
+++ b/test/FlashFloopExecutor.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import '@nomicfoundation/hardhat-chai-matchers';
+
+describe('FlashFloopExecutor', function () {
+  let recipient: string;
+  let executor: Contract;
+  let vault: Contract;
+  let token: Contract;
+  let target: Contract;
+
+  const loanAmount = ethers.parseUnits('100', 18);
+
+  beforeEach(async () => {
+    const [, profitRecipient] = await ethers.getSigners();
+    recipient = await profitRecipient.getAddress();
+
+    const tokenFactory = await ethers.getContractFactory('MockERC20');
+    token = await tokenFactory.deploy('Mock Token', 'MOCK', 18);
+    await token.waitForDeployment();
+
+    const vaultFactory = await ethers.getContractFactory('MockBalancerVault');
+    vault = await vaultFactory.deploy();
+    await vault.waitForDeployment();
+
+    const targetFactory = await ethers.getContractFactory('MockPipelineTarget');
+    target = await targetFactory.deploy();
+    await target.waitForDeployment();
+
+    const executorFactory = await ethers.getContractFactory('FlashFloopExecutor');
+    executor = await executorFactory.deploy(await vault.getAddress());
+    await executor.waitForDeployment();
+
+    await token.mint(await vault.getAddress(), ethers.parseUnits('1000000', 18));
+    await token.mint(await target.getAddress(), ethers.parseUnits('1000', 18));
+  });
+
+  it('reverts when targets and calldatas length mismatch', async () => {
+    await expect(
+      executor.execute({
+        targets: [await target.getAddress()],
+        calldatas: [],
+        loanToken: await token.getAddress(),
+        loanAmount,
+        minProfit: 0n,
+        profitRecipient: recipient
+      })
+    ).to.be.revertedWithCustomError(executor, 'BadLengths');
+  });
+
+  it('reverts when loan token differs from expectation', async () => {
+    const otherTokenFactory = await ethers.getContractFactory('MockERC20');
+    const otherToken = await otherTokenFactory.deploy('Other Token', 'OT', 18);
+    await otherToken.waitForDeployment();
+    await otherToken.mint(await vault.getAddress(), ethers.parseUnits('1000', 18));
+
+    await vault.setOverrideResponse([await otherToken.getAddress()], [loanAmount]);
+
+    await expect(
+      executor.execute({
+        targets: [],
+        calldatas: [],
+        loanToken: await token.getAddress(),
+        loanAmount,
+        minProfit: 0n,
+        profitRecipient: recipient
+      })
+    ).to.be.revertedWithCustomError(executor, 'UnexpectedLoanToken');
+  });
+
+  it('reverts when loan amount differs from expectation', async () => {
+    await vault.setOverrideResponse([await token.getAddress()], [loanAmount + 1n]);
+
+    await expect(
+      executor.execute({
+        targets: [],
+        calldatas: [],
+        loanToken: await token.getAddress(),
+        loanAmount,
+        minProfit: 0n,
+        profitRecipient: recipient
+      })
+    ).to.be.revertedWithCustomError(executor, 'UnexpectedLoanAmount');
+  });
+
+  it('reverts when minimum profit is not achieved', async () => {
+    const minProfit = ethers.parseUnits('1', 16);
+    await expect(
+      executor.execute({
+        targets: [],
+        calldatas: [],
+        loanToken: await token.getAddress(),
+        loanAmount,
+        minProfit,
+        profitRecipient: recipient
+      })
+    ).to.be.revertedWithCustomError(executor, 'InsufficientProfit');
+  });
+
+  it('executes successfully and forwards leftover profit', async () => {
+    const minProfit = ethers.parseUnits('5', 16);
+    const fee = ethers.parseUnits('1', 16);
+    await vault.setFlashFee(fee);
+
+    const extraProfit = ethers.parseUnits('2', 16);
+    const profitToSend = minProfit + fee + extraProfit;
+
+    const targetInterface = target.interface;
+    const callData = targetInterface.encodeFunctionData('send', [
+      await token.getAddress(),
+      await executor.getAddress(),
+      profitToSend
+    ]);
+
+    await expect(
+      executor.execute({
+        targets: [await target.getAddress()],
+        calldatas: [callData],
+        loanToken: await token.getAddress(),
+        loanAmount,
+        minProfit,
+        profitRecipient: recipient
+      })
+    ).to.emit(token, 'Transfer');
+
+    const recipientBalance = await token.balanceOf(recipient);
+    expect(recipientBalance).to.equal(minProfit + extraProfit);
+
+    const vaultBalance = await token.balanceOf(await vault.getAddress());
+    const expectedVaultBalance = ethers.parseUnits('1000000', 18) + fee;
+    expect(vaultBalance).to.equal(expectedVaultBalance);
+  });
+});


### PR DESCRIPTION
## Summary
- allow autonomous plans to declare artifact directories and run labels for recording live executions
- persist plan snapshots, attempt metadata, and a markdown report for each autonomous run while exposing the data through the summary return value
- extend the autonomous runner integration tests to assert artifact emission alongside existing success and guardrail flows

## Testing
- pnpm run build
- pnpm hardhat test

------
https://chatgpt.com/codex/tasks/task_e_68d78f5b77b483289f234ed6e8f45d39